### PR TITLE
[FIX]Set configPaths options empty object by default

### DIFF
--- a/packages/react-app-alias/src/index.js
+++ b/packages/react-app-alias/src/index.js
@@ -180,7 +180,7 @@ function configPaths(configPath = '', confUndoc) {
   return aliasMap
 }
 
-function defaultOptions(options) {
+function defaultOptions(options = {}) {
   const configPath = configFilePathSafe(
     options.tsconfig || options.jsconfig
   )


### PR DESCRIPTION
The configPaths option can be empty by default and use the default
attributes for tsconfig.json or jsconfig.json. Thus the options
object should be allowed to be undefined so that we don't overload
the config with an empty object if we don't need to define another
path for ts/jsonconfig.